### PR TITLE
Support "important" and "negative"

### DIFF
--- a/assets/javascripts/discourse-markdown/notifications.js.es6
+++ b/assets/javascripts/discourse-markdown/notifications.js.es6
@@ -6,6 +6,8 @@ export function setup(helper) {
             'div.p-notification',
             'div.p-notification--caution',
             'div.p-notification--positive',
+            'div.p-notification--negative',
+            'div.p-notification--important',
             'p.p-notification__response',
             'span.p-notification__status',
             'span.p-notification__line'
@@ -27,7 +29,9 @@ export function setup(helper) {
 
                 if (
                     'type' in tagInfo.attrs
-                    && ['caution', 'positive'].includes(tagInfo.attrs.type.toLowerCase())
+                    && ['caution', 'positive', 'negative', 'important'].includes(
+                        tagInfo.attrs.type.toLowerCase()
+                    )
                 ) {
                     type = "--" + tagInfo.attrs.type.toLowerCase();
                 }

--- a/assets/stylesheets/notifications.scss
+++ b/assets/stylesheets/notifications.scss
@@ -11,6 +11,14 @@
   border-color:#0e8420;
 }
 
+.p-notification--negative .p-notification__response {
+  border-color:#c7162b;
+}
+
+.p-notification--important .p-notification__response {
+  border-color:#335280;
+}
+
 .p-notification__status {
   font-weight: bold;
 }


### PR DESCRIPTION
Same as https://github.com/canonical-webteam/discourse-markdown-note/pull/2, but with 2 new types - "important" and "negative". To complete the set from https://docs.vanillaframework.io/en/patterns/notification.

QA
--

Same as in https://github.com/canonical-webteam/discourse-markdown-note/pull/2