### PR TITLE
Rewrite using tokens

### DIFF
--- a/assets/javascripts/discourse-markdown/notifications.js.es6
+++ b/assets/javascripts/discourse-markdown/notifications.js.es6
@@ -9,43 +9,47 @@ export function setup(helper) {
             'div.p-notification--negative',
             'div.p-notification--important',
             'p.p-notification__response',
-            'span.p-notification__status',
-            'span.p-notification__line'
+            'span.p-notification__status'
         ]
     );
 
     helper.registerPlugin(md=>{
-        md.block.bbcode.ruler.push('note', {
-            tag: 'note',
+        md.block.bbcode.ruler.push("note", {
+            tag: "note",
             replace: function(state, tagInfo, content) {
-                let status = "";
-                let type = "";
-
-                if ('status' in tagInfo.attrs) {
-                    status = '<span class="p-notification__status">'
-                    + tagInfo.attrs.status
-                    + ':</span>'
-                }
-
+                // Build up the notification class from the specified "type"
+                // "p-notification--{type}"
+                let notificationClass = 'p-notification'
                 if (
                     'type' in tagInfo.attrs
                     && ['caution', 'positive', 'negative', 'important'].includes(
                         tagInfo.attrs.type.toLowerCase()
                     )
                 ) {
-                    type = "--" + tagInfo.attrs.type.toLowerCase();
+                    notificationClass += "--" + tagInfo.attrs.type.toLowerCase();
                 }
 
-                let notification_block = state.push('html_raw', '', 0);
+                // Start wrapper elements:
+                // <div class="p-notification"><p class="p-notification__render">
+                state.push('div_open', 'div', 1).attrSet('class', notificationClass);
+                state.push('paragraph_open', 'p', 1).attrSet('class', 'p-notification__response');
 
-                let rendered_contents = md.render(content).trim().replace(/^<p>|<\/p>$/g, '')
+                // Add status:
+                // <span class="p-notification__status">{status}</span>
+                if ('status' in tagInfo.attrs) {
+                    state.push('span_open', 'span', 1).attrSet('class', 'p-notification__status');
+                    state.push('text', '', 0).content  = tagInfo.attrs.status + ": ";
+                    state.push('span_close', 'span', -1);
+                }
 
-                notification_block.content = '<div class="p-notification' + type + '">'
-                    +  '  <p class="p-notification__response">'
-                    +  status + '\n'
-                    +  rendered_contents
-                    +  '  </p>'
-                    +  '</div>';
+                // Add the [note] content inline
+                let token = state.push('inline', '', 0);
+                token.content  = content;
+                token.children = [];
+
+                // Close the wrapper elements
+                state.push('paragraph_close', 'p', -1);
+                state.push('div_close', 'div', -1);
 
                 return true;
             }


### PR DESCRIPTION
This should be a more robust implementation, safe against XSS attacks.

QA
--

To run Discourse:

``` bash
git clone git@github.com:discourse/discourse.git
cd discourse
git clone -b rewrite-with-tokens git@github.com:nottrobin/discourse-markdown-note plugins/discourse-markdown-note
./bin/docker/boot_dev --init
./bin/docker/rails s
```

Once you've got the server running, go to http://localhost:3000, and log in with the admin user you just created.

Now check:

- Markdown inside `[note]` blocks is successfully parsed
- Text inside the `status` is treated as plain text
- You cannot inject malicious elements or attributes

You can test this by creating a new post with the following contents:

``` bash
[note]
Things *are* reasonable
[/note]

[note type=caution]
I have **no** title
[/note]

[note type=positive status="*Awesome*"]
Everything is now wonderful
[/note]

[note type="<script>alert()</script>" status="<i onclick=alert()>Awesome*</i>"]
<i onclick='alert()'>ITALICS!!*</i>
<script>alert()</script>
[/note]
```

Check none of the `alert()`s can be triggered.